### PR TITLE
CAH-0025 add offline user status

### DIFF
--- a/CAH-Application-Mongo/public/DOM/dom.js
+++ b/CAH-Application-Mongo/public/DOM/dom.js
@@ -122,9 +122,12 @@ function outputRoomUserTable(GameState) {
 	if(user.status == 'active') {
 		tdName.style.color = "black";
 		tdName.innerHTML = `${user.username}`;
-	} else {
+	} else if(user.status == 'idle'){
 		tdName.style.color = "red";
 		tdName.innerHTML = `${user.username} (busy)`;
+	} else {
+		tdName.style.color = "red";
+		tdName.innerHTML = `${user.username} (offline)`;		
 	}
 	tr.appendChild(tdName);
 	const tdPoints = document.createElement('td');

--- a/CAH-Application-Mongo/utils/users.js
+++ b/CAH-Application-Mongo/utils/users.js
@@ -16,6 +16,22 @@ function setInactiveUser(currentUser) {
 	});	
 }
 
+function setLeavingUser(currentUser) {
+	users.forEach(user => {
+		if(user.username == currentUser.username) {
+			user.status = 'offline';
+		}
+	});	
+}
+
+function dropOfflineUsers() {
+	users.forEach(user => {
+		if(user.status == 'offline') {
+			users.splice(users.findIndex(user => user.status === 'offline'),1);
+		}
+	});	
+}
+
 function getCurrentUserByUsername(username) {
 	return users.find(user => user.username === username);
 }
@@ -94,5 +110,7 @@ module.exports = {
   userRejoin,
   setIdleUser,
   getCurrentUserByUsername,
-  setInactiveUser
+  setInactiveUser, 
+  setLeavingUser,
+  dropOfflineUsers
 };


### PR DESCRIPTION
Added offline user status
'Offline' is a mid-round user status that occurs when...
1.) User closes browser
2.) Timeouts idle status (90 sec)

Its purpose is to maintain integrity of gameloop in the event that a user leaves the room mid-way through a round.  
Offline users are removed from room at the onset of a new round.